### PR TITLE
qca : incorporate patch to qca_basic.h from homebrew

### DIFF
--- a/qca.rb
+++ b/qca.rb
@@ -26,6 +26,12 @@ class Qca < Formula
     depends_on "doxygen" => [:build, "with-dot"]
   end
 
+    # Fixes build with Qt 5.5 by adding a missing include (already fixed in HEAD).
+  patch do
+    url "http://quickgit.kde.org/?p=qca.git&a=commitdiff&h=7207e6285e932044cd66d49d0dc484666cfb0092&o=plain"
+    sha256 "b3ab2eb010f4a16f85349e4b858d0ee17a84ba2927311b79aeeff1bb2465cd3d"
+  end
+
   def install
     args = std_cmake_args
     args << "-DQT4_BUILD=OFF"


### PR DESCRIPTION
There was a patch in https://github.com/Homebrew/homebrew/blob/master/Library/Formula/qca.rb 
allowing for a compilation of qca to go through. 
Otherwise the compilation of qca ends with an error: 
``qca_basic.h:325:14: error: unknown type name 'QIODevice'`` 