### PR TITLE
Fix qt5webkit formula

### DIFF
--- a/qt5webkit.rb
+++ b/qt5webkit.rb
@@ -7,8 +7,10 @@ class Qt5webkit < Formula
   depends_on 'qt5'
 
   def install
-    system "qmake"
+
+    qmake_args = ["-config", "release", "PREFIX=/"]
+    system "qmake", *qmake_args
     system "make"
-    system "make install"
+    system "make", "INSTALL_ROOT=#{prefix}", "install"
   end
 end


### PR DESCRIPTION
so, it installs into 
```

$ ls /usr/local/Cellar/qt5webkit/5.6.0/usr/local/Cellar/qt5/5.6.0/
lib	libexec	mkspecs	qml

```

PREFIX on qmake was trying to change this but doesn't seem to

anyhow its enough at least for tomahawk to be compiled