### PR TITLE
Fix broken link in qca formula

### DIFF
--- a/qca.rb
+++ b/qca.rb
@@ -28,8 +28,8 @@ class Qca < Formula
 
     # Fixes build with Qt 5.5 by adding a missing include (already fixed in HEAD).
   patch do
-    url "http://quickgit.kde.org/?p=qca.git&a=commitdiff&h=7207e6285e932044cd66d49d0dc484666cfb0092&o=plain"
-    sha256 "b3ab2eb010f4a16f85349e4b858d0ee17a84ba2927311b79aeeff1bb2465cd3d"
+    url "https://cgit.kde.org/qca.git/patch/?id=7207e6285e932044cd66d49d0dc484666cfb0092"
+    sha256 "c9a916617ee6f084bae406765310896bd955667c3a0fbeb175a2b819f67ff4b5"
   end
 
   def install


### PR DESCRIPTION
QCA project repository was moved to a new location. Adjust formula to the new location. 